### PR TITLE
管理者用ページの実装

### DIFF
--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -1,0 +1,58 @@
+class Admin::ArticlesController < Admin::Base
+
+  def index
+    @articles = Article.order(released_at: :desc).paginate(page: params[:page], per_page: 10)
+  end
+
+  def show
+    articles = Article.find(params[:id])
+  end
+
+  def new
+    @article = Article.new
+  end
+
+  def edit
+    @article = Article.find(params[:id])
+  end
+
+  def create
+    @article = Article.new(article_params)
+    if @article.save
+      redirect_to [:admin, @article], notice: "ニュース記事を登録しました。"
+    else
+      render "new"
+    end
+  end
+
+  def update
+    @article = Article.find(params[:id])
+    @article.assign_attributes(article_params)
+    if @article.save
+      redirect_to [:admin, @article], notice: "ニュース記事を更新しました。"
+    else
+      render "edit"
+    end
+  end
+
+  def destroy
+    @article = Article.find(params[:id])
+    @article.destroy
+    redirect_to :admin_articles
+  end
+
+  private
+
+  def article_params
+    params.require(:article).permit(
+      :title,
+      :new_info_picture,
+      :remove_info_picture,
+      :body,
+      :released_at,
+      :no_expiration,
+      :expired_at,
+      :member_only
+    )
+  end
+end

--- a/app/controllers/admin/base.rb
+++ b/app/controllers/admin/base.rb
@@ -1,0 +1,7 @@
+class Admin::Base < ApplicationController
+  before_action :admin_login_required
+
+  private def admin_login_required
+    raise Forbidden unless current_member&.admin?
+  end
+end

--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -1,0 +1,18 @@
+class Admin::MembersController < Admin::Base
+
+  def index
+    @members = Member.paginate(page: params[:page], per_page: 15)
+  end
+
+  def show
+    @member = Member.find(params[:id])
+    @entries = @member.entries.paginate(page: params[:page], per_page: 3)
+    # debugger
+  end
+
+  def destroy
+    Member.find(params[:id]).destroy
+    flash[:success] = "Member deleted"
+    redirect_to :admin_members, notice: "会員を削除しました。"
+  end
+end

--- a/app/controllers/admin/top_controller.rb
+++ b/app/controllers/admin/top_controller.rb
@@ -1,0 +1,4 @@
+class Admin::TopController < Admin::Base
+  def index
+  end
+end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,14 +1,16 @@
 class ArticlesController < ApplicationController
 
+  # 記事一覧
   def index
     @articles = Article.visible.order(released_at: :desc)
     @articles = @articles.open_to_the_public unless current_member
     @articles = @articles.paginate(page: params[:page], per_page: 4)
   end
 
+  # 記事詳細
   def show
-    article = Artcle.visible
-    article = articles.open_to_the_public unless current_member
+    articles = Article.visible
+    articles = articles.open_to_the_public unless current_member
     @article = articles.find(params[:id])
   end
 end

--- a/app/helpers/entries_helper.rb
+++ b/app/helpers/entries_helper.rb
@@ -8,7 +8,7 @@ module EntriesHelper
   def other_images(entry)
     buffer = "".html_safe
 
-    entry.images.other(:position)[1..-1]&.each do |image|
+    entry.images.order(:position)[1..-1]&.each do |image|
       buffer << render_entry_image(image)
     end
 

--- a/app/views/admin/articles/_form.html.erb
+++ b/app/views/admin/articles/_form.html.erb
@@ -1,0 +1,61 @@
+<table class="attr" border="1">
+  <tr>
+    <th class="profile-user" colspan="2">画像を選択</th>
+  </tr>
+  <tr>
+    <td class="profile-user" colsapn="2">
+      <%= form.file_field :new_info_picture, :class => "btn btn-form" %>
+    </td>
+  </tr>
+  <tr>
+    <th colsapn="2" class="profile-user"><%= form.label :new_info_picture %></th>
+  </tr>
+  <tr>
+    <td class="prof-content" colspan="2">
+      <% if @article.info_picture.attached? %>
+        <div class="image-pic">
+          <%= image_tag @article.info_picture.variant(resize: "128x128") %>
+          <%= form.check_box :remove_info_picture, :class => "chkbox" %>
+          <%= form.label :remove_info_picture %>
+        </div>
+      <% else %>
+        <div class="no-pic">画像はありません。</div>
+      <% end %>
+    </td>
+  </tr>
+  <tr>
+    <th class="article-name" width="100"><%= form.label :title %></th>
+    <td><%= form.text_field :title, size: 44, :class => "image-field" %></td>
+  </tr>
+  <tr>
+    <th><%= form.label :body %></th>
+    <td><%= form.text_area :body, rows: 10, cols: 45, :class => "image-fied" %></td>
+  </tr>
+  <tr>
+    <th class="start-date"><%= form.label :released_at, for: "article_released_at_1i" %></th>
+    <td><%= form.datetime_select :released_at,
+              start_year: 2000, end_year: Time.current.year + 1,
+              use_month_numbers: true %></td>
+  </tr>
+  <tr>
+    <th><%= form.label :expired_at, for: "article_expired_at_1i" %></th>
+    <td class="article-expired">
+      <div class="article-chk">
+        <%= form.check_box :no_expiration, :class => "chkbox" %>
+        <%= form.label :no_expiration, {class: 'no-exp'} %>
+      </div>
+      <div class="article_expired_at">
+        <%= form.datetime_select :expired_at,
+          start_year: 2000, end_year: Time.current.year + 1,
+          user_month_numbers: true %>
+      </div>
+    </td>
+  </tr>
+  <tr>
+    <th class="member-only"><%= Article.human_attribute_name(:member_only) %></th>
+    <td>
+      <div class="chk"><%= form.check_box :member_only, :class => "chkbox" %></div>
+      <%= form.label :member_only, {class: 'member-only'} %>
+    </td>
+  </tr>
+</table>

--- a/app/views/admin/articles/edit.html.erb
+++ b/app/views/admin/articles/edit.html.erb
@@ -1,0 +1,9 @@
+<% provide(:title, "ニュース記事の編集") %>
+<div class="edit-articles-news">ニュース記事の編集</div>
+
+<p class="article-edit"><%= link_to "記事の詳細に戻る", [:admin, @article], :class => "back-show" %></p>
+
+<%= form_for [:admin, @article] do |form| %>
+  <%= render "form", form: form %>
+  <div><%= form.submit '更新', class: 'btn btn-primary' %></div>
+<% end %>

--- a/app/views/admin/articles/index.html.erb
+++ b/app/views/admin/articles/index.html.erb
@@ -1,0 +1,33 @@
+<% provide(:title, "Articles") %>
+<div class="article-show">
+    <h1>新着情報一覧</h1>
+
+  <div class="article-new"><%= link_to "新規作成", :new_admin_article %></div>
+
+  <% if @articles.present? %>
+    <table class="list" border="1">
+      <thead>
+        <tr>
+          <th class="admin-article-title">タイトル</th>
+          <th class="admin-article-date">日時</th>
+          <th class="article-control">操作</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @articles.each do |article| %>
+        <tr>
+            <td><%= link_to article.title, [:admin, article] %></td>
+            <td class="admin-article-date"><%= article.released_at.strftime("%Y/%m/%d %H:%M") %></td>
+            <td class="article-control">
+              <%= link_to "編集", [:edit, :admin, article] %> |
+              <%= link_to "削除", [:admin, article], method: :delete,
+                data: { confirm: "本当に削除しますか？" } %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <%= paginate @articles %>
+<% else %>
+  <p>ニュースがありません。</p>
+<% end %>

--- a/app/views/admin/articles/new.html.erb
+++ b/app/views/admin/articles/new.html.erb
@@ -1,0 +1,6 @@
+<% provide(:title, "ニュース新規掲載") %>
+<div class="news-article-create">ニュース記事新規掲載</div>
+<%= form_for [:admin, @article] do |form| %>
+  <%= render "form", form: form %>
+  <div><%= form.submit '登録', class: 'btn btn-primary' %></div>
+<% end %>

--- a/app/views/admin/articles/show.html.erb
+++ b/app/views/admin/articles/show.html.erb
@@ -1,0 +1,12 @@
+<% provide(:title, @article.title) %>
+<h1 class="news-show"><%= @article.title %></h1>
+<p>
+<% if @article.info_picture.attached? %>
+  <%= image_tag @article.info_picture.valiant(resize: "200x200") %>
+<% end %>
+</p>
+<%= auto_link simple_format(@article.body) %>
+
+<div>
+  <%= @article.released_at.strftime("%Y/%m/%d %H:%M") %>
+</div>

--- a/app/views/admin/members/index.html.erb
+++ b/app/views/admin/members/index.html.erb
@@ -1,0 +1,29 @@
+<% provide(:title, '会員管理') %>
+<h1 class="admin-user-title">会員管理</h1>
+
+<table class="list" border="1">
+  <thead>
+    <tr>
+      <th class="user-name">ユーザー名</th>
+      <th class="admin-user-pic">画像</th>
+      <th class="user-control">操作</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @members.each do |member| %>
+      <tr>
+        <td class="user-name"><%= link_to member.name, member %></td>
+        <td class="user-pic">
+            <% if member.profile_picture.attached? %>
+            <%= image_tag member.profile_picture.variant(resize: 50) %>
+          <% end %>
+        </td>
+        <td class="user-control">
+          <%= link_to "削除", [:admin, member], method: :delete,
+            data: { confirm: "本当に削除しますか？" } %>
+        </td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+<%= paginate @members %>

--- a/app/views/admin/top/index.html.erb
+++ b/app/views/admin/top/index.html.erb
@@ -1,0 +1,8 @@
+<% provide(:title, '管理ページトップ') %>
+
+<div class="admin-top">
+<ul>
+  <li><%= link_to "会員管理", :admin_members %></li>
+  <li><%= link_to "ニュース記事管理", :admin_articles %></li>
+</ul>
+</div>

--- a/app/views/entries/edit.html.erb
+++ b/app/views/entries/edit.html.erb
@@ -1,5 +1,5 @@
 <% provide(:title, 'ブログ記事の編集') %>
-<h1><%= @page_title = "ブログ記事の編集" %>%</h1>
+<h1><%= @page_title = "ブログ記事の編集" %></h1>
 
 <div class="toolbar"><%= link_to "記事の表示に戻る", @entry %></div>
 

--- a/app/views/shared/_admin_menubar.html.erb
+++ b/app/views/shared/_admin_menubar.html.erb
@@ -1,0 +1,8 @@
+<nav class="menubar" id="admin-menubar">
+  <ul>
+    <%= menu_link_to "管理TOP", :admin_root %>
+    <%= menu_link_to "会員管理", :admin_members %>
+    <%= menu_link_to "ニュース記事管理", :admin_articles %>
+    <%= menu_link_to "TOP", :root %>
+  </ul>
+</nav>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,9 @@
 <%= image_tag "coollogo_com-21817846.png", size: "272x48", alt: "NM Helth Food Web Shop", :class => "logos" %>
 
 <%=
-  render "shared/menubar"
+  if controller.kind_of?(Admin::Base)
+    render "shared/admin_menubar"
+  else
+    render "shared/menubar"
+  end
 %>

--- a/app/views/shared/_menubar.html.erb
+++ b/app/views/shared/_menubar.html.erb
@@ -18,8 +18,9 @@
         </li>
     </ul>
   </li>
-
-        <%= menu_link_to "管理ページ", "#" %>
-    <% end %>  
+      <% if current_member.admin? %>
+        <%= menu_link_to "管理ページ", :admin_root %>
+      <% end %>
+    <% end %>
   </ul>
 </nav>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,13 +1,13 @@
 <% provide(:title, "Home") %>
-
+<% unless logged_in? %>
   <h2 class="info1">会員限定ページはサインアップ！</h2>
   <div class="info2">認証メールが届きますのでActivateをクリックしてください。</div>
-
+<% end %>
 <h3 class="top-title">新着情報</h3>
-<% 5.times do |x| %>
-  <h2>見出し</h2>
+<% @articles.each do |article| %>
+  <h2><%= article.title %></h2>
   <p>
-    ここに本文が入ります。ここに本文が入ります。ここに本文が入ります。ここに本文が入ります。ここに本文が入ります。
-    <%= link_to "もっと読む", "#" %>
+    <%= truncate article.body, length: 80 %>
+    <%= link_to "もっと読む", article %>
   </p>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,4 +24,12 @@ Rails.application.routes.draw do
       patch :move_higher, :move_lower, on: :member
     end
   end
+
+  namespace :admin do
+    root to: "top#index"
+    resources :members do
+      get "search", on: :collection
+    end
+    resources :articles
+  end
 end

--- a/db/migrate/20190613140108_add_admin_to_members.rb
+++ b/db/migrate/20190613140108_add_admin_to_members.rb
@@ -1,0 +1,5 @@
+class AddAdminToMembers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :members, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_13_083254) do
+ActiveRecord::Schema.define(version: 2019_06_13_140108) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -76,6 +76,7 @@ ActiveRecord::Schema.define(version: 2019_06_13_083254) do
     t.datetime "activated_at"
     t.string "reset_digest"
     t.datetime "reset_sent_at"
+    t.boolean "admin", default: false
     t.index ["email"], name: "index_members_on_email", unique: true
   end
 


### PR DESCRIPTION
# WHAT
管理者用ページの実装

# WHY
管理者のみがニュース及び会員メンバー等の管理を行えるようにすることは必須である